### PR TITLE
Fixing the connection manager (V 1.4.0)

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@
 # SplitDb
 #### Magento 2 module to redirect SELECT queries to another database connection.  
 
-![Version 1.2.0](https://img.shields.io/badge/Version-1.2.0-green.svg)
+![Version 1.4.0](https://img.shields.io/badge/Version-1.4.0-green.svg)
 
 ## Manual Install
 

--- a/app/code/MageMojo/SplitDb/Adapter/Pdo/Mysql.php
+++ b/app/code/MageMojo/SplitDb/Adapter/Pdo/Mysql.php
@@ -41,27 +41,21 @@ class Mysql extends OriginalMysqlPdo
     {
         $isConnected = (bool) ($this->_connection);
 
-        // Get the connection according the sql query
-//        $this->getConnectionBySql($sql);
-
-//         Check if the forced mode is the same currently utilized
+        // Check if the forced mode is the same currently utilized
         if($sql == 'write' && $this->isUsingReadConnection()){
-            $this->setConfig($this->getConfigWrite());
             $this->getConnectionBySql('write');
         }elseif($sql == 'read' && !$this->isUsingReadConnection()){
-            $this->setConfig($this->getConfigRead());
             $this->getConnectionBySql('read');
         }
 
         // Check if need to connect
         if($isConnected) {
             if (($this->isSelect($sql) || $sql == 'read') && !$this->isUsingReadConnection()) {
-                $this->setConfig($this->getConfigRead());
                 $this->getConnectionBySql('read');
             } elseif ((!$this->isSelect($sql) || $sql == 'write') && $this->isUsingReadConnection()) {
-                $this->setConfig($this->getConfigWrite());
                 $this->getConnectionBySql('write');
             }
+
             return;
         }
 
@@ -610,11 +604,11 @@ class Mysql extends OriginalMysqlPdo
     public function query($sql, $bind = array())
     {
         // connect to the database if needed
-        $this->_connect($sql);
-
-//        if($this->getConfig()['username'] == 'custom' && strpos($sql, 'INSERT') !== false){
-//            var_dump($sql);exit;
-//        }
+        if ($this->isSelect($sql)){
+            $this->_connect('read');
+        }else{
+            $this->_connect($sql);
+        }
 
         // is the $sql a Zend_Db_Select object?
         if ($sql instanceof Zend_Db_Select) {

--- a/app/code/MageMojo/SplitDb/composer.json
+++ b/app/code/MageMojo/SplitDb/composer.json
@@ -6,7 +6,7 @@
         "magento/magento-composer-installer": "*"
     },
     "type": "magento2-module",
-    "version": "1.2.0",
+    "version": "1.4.0",
     "license": [
         "OSL-3.0",
         "AFL-3.0"

--- a/app/code/MageMojo/SplitDb/etc/module.xml
+++ b/app/code/MageMojo/SplitDb/etc/module.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0"?>
 <config xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
         xsi:noNamespaceSchemaLocation="urn:magento:framework:Module/etc/module.xsd">
-    <module name="MageMojo_SplitDb" setup_version="1.2.0">
+    <module name="MageMojo_SplitDb" setup_version="1.4.0">
         <sequence>
             <module name="Magento_Deploy"/>
         </sequence>


### PR DESCRIPTION
Make sure that you're using your `app/etc/env.php` like this below.

```
'db' => 
  array (
    'table_prefix' => '',
    'connection' => 
    array (
      'default' => 
      array (
        'host' => 'db',
        'dbname' => 'magento',
        'username' => 'root',
        'password' => 'root',
        'model' => 'mysql4',
        'engine' => 'innodb',
        'initStatements' => 'SET NAMES utf8;',
        'active' => '1',
      ),
      'readonly' => 
      array (
        'host' => 'db',
        'dbname' => 'magento',
        'username' => 'custom',
        'password' => 'root',
        'model' => 'mysql4',
        'engine' => 'innodb',
        'initStatements' => 'SET NAMES utf8;',
        'active' => '1',
      ),
    ),
  ),
  'resource' => 
  array (
    'default_setup' => 
    array (
      'connection' => 'default',
    ),
    'readonly_setup' => 
    array (
      'connection' => 'readonly',
    ),
  ),
```