### PR TITLE
Ignoring the _tmp_ tables when switch the DB connector

### DIFF
--- a/app/code/MageMojo/SplitDb/Adapter/Pdo/Mysql.php
+++ b/app/code/MageMojo/SplitDb/Adapter/Pdo/Mysql.php
@@ -369,7 +369,7 @@ class Mysql extends OriginalMysqlPdo
      */
     protected function _ignoreSQL($sql){
 
-        $ignoreTempQueries = ['eav_attribute'];
+        $ignoreTempQueries = ['eav_attribute', '_tmp_'];
 
         $toIgnore = ((strpos(substr($sql, 0, 10), 'SET NAMES') !== false) || $sql == false);
 


### PR DESCRIPTION
**Search_tmp tables fail**
https://github.com/magemojo/m2-ce-splitdb/issues/11